### PR TITLE
Add .NET Standard 2.0 target

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,8 +3,8 @@
 #addin "nuget:?package=NuGet.Core"
 
 var target = Argument("target", "Default");
-var version = "1.8.0";
-string preRelease = null;
+var version = "1.9.0";
+string preRelease = "alpha";
 var nugetVersion = version + (preRelease == null ? "" : "-" + preRelease);
 var distDir = "./dist/" + nugetVersion;
 
@@ -67,6 +67,8 @@ Task("CopyNuGetLib")
     CopyFiles("./src/netcore/bin/Release/netstandard1.4/VDS.Common.*", "./Build/NuGet/lib/netstandard1.4");
 	EnsureDirectoryExists("./Build/NuGet/lib/netstandard1.0");
     CopyFiles("./src/netcore/bin/Release/netstandard1.0/VDS.Common.*", "./Build/NuGet/lib/netstandard1.0");
+	EnsureDirectoryExists("./Build/NuGet/lib/netstandard2.0");
+    CopyFiles("./src/netcore/bin/Release/netstandard2.0/VDS.Common.*", "./Build/NuGet/lib/netstandard2.0");
 });
 
 Task("NuGet")

--- a/src/net35-client/Properties/AssemblyInfo.cs
+++ b/src/net35-client/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("VDS.Common")]
-[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2014")]
+[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
@@ -26,8 +26,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]
 
 
 

--- a/src/net40-client/Properties/AssemblyInfo.cs
+++ b/src/net40-client/Properties/AssemblyInfo.cs
@@ -28,11 +28,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("VDS.Common")]
-[assembly: AssemblyDescription("Common data structures for .Net projects (.Net 4.0 Client Profile Build)")]
+[assembly: AssemblyDescription("Common data structures for .Net projects")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("VDS.Common")]
-[assembly: AssemblyCopyright("Copyright © Robert Vesse and others 2012-2016")]
+[assembly: AssemblyCopyright("Copyright © Robert Vesse and others 2012-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
@@ -47,8 +47,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]
 
 
 

--- a/src/netcore/netcore.csproj
+++ b/src/netcore/netcore.csproj
@@ -6,11 +6,12 @@
     <AssemblyTitle>VDS.Common</AssemblyTitle>
     <VersionPrefix>1.8.0</VersionPrefix>
     <Authors>Rob Vesse;Khalil Ahmed</Authors>
-    <TargetFrameworks>netstandard1.4;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;netstandard1.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>VDS.Common</AssemblyName>
     <PackageId>netcore</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.0</NetStandardImplicitPackageVersion>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.4' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.1</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/portable/Properties/AssemblyInfo.cs
+++ b/src/portable/Properties/AssemblyInfo.cs
@@ -28,11 +28,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("VDS.Common")]
-[assembly: AssemblyDescription("Common data structures for .Net projects (.Net Portable Library Build)")]
+[assembly: AssemblyDescription("Common data structures for .Net projects")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("VDS.Common")]
-[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2014")]
+[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
@@ -47,8 +47,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]
 
 
 

--- a/test/Properties/AssemblyInfo.cs
+++ b/test/Properties/AssemblyInfo.cs
@@ -31,7 +31,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Visual Design Studios")]
 [assembly: AssemblyProduct("VDS.Common.Test")]
-[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2014")]
+[assembly: AssemblyCopyright("Copyright © Robert Vesse 2012-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -52,8 +52,8 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.8.0.0")]
-[assembly: AssemblyFileVersion("1.8.0.0")]
+[assembly: AssemblyVersion("1.9.0.0")]
+[assembly: AssemblyFileVersion("1.9.0.0")]
 
 
 

--- a/test/VDS.Common.Test.csproj
+++ b/test/VDS.Common.Test.csproj
@@ -33,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/test/packages.config
+++ b/test/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This PR adds .NET Standard 2.0 to the netcore build. It also bumps the version number to 1.9.0-alpha in preparation for a release.