### PR TITLE
Fix memory usage on remove from MultiDictionary

### DIFF
--- a/src/net40-client/Collections/MultiDictionary.cs
+++ b/src/net40-client/Collections/MultiDictionary.cs
@@ -252,7 +252,13 @@ namespace VDS.Common.Collections
             int hash = this._hashFunc(key);
             if (this._dict.TryGetValue(hash, out tree))
             {
-                return tree.Remove(key);
+                boolean removed = tree.Remove(key);
+                if (removed && tree.Root == null)
+                {
+                  // Clear up empty trees
+                  this._dict.Remove(key);
+                }
+                return removed;
             }
             else
             {

--- a/src/net40-client/Collections/MultiDictionary.cs
+++ b/src/net40-client/Collections/MultiDictionary.cs
@@ -252,7 +252,7 @@ namespace VDS.Common.Collections
             int hash = this._hashFunc(key);
             if (this._dict.TryGetValue(hash, out tree))
             {
-                boolean removed = tree.Remove(key);
+                bool removed = tree.Remove(key);
                 if (removed && tree.Root == null)
                 {
                   // Clear up empty trees

--- a/src/net40-client/Collections/MultiDictionary.cs
+++ b/src/net40-client/Collections/MultiDictionary.cs
@@ -256,7 +256,7 @@ namespace VDS.Common.Collections
                 if (removed && tree.Root == null)
                 {
                   // Clear up empty trees
-                  this._dict.Remove(key);
+                  this._dict.Remove(hash);
                 }
                 return removed;
             }


### PR DESCRIPTION
When removing from a MultiDictionary check if the tree used for the hash code is now empty and if so remove that tree.

This affects usage patterns where callers empty the tree via calls to `Remove()` rather than via calling `Clear()` explicitly