### PR TITLE
Performance, thread safety, and language/framework modernization

### DIFF
--- a/VDS.Common.sln
+++ b/VDS.Common.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33627.172
@@ -10,7 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\build.yaml = .github\workflows\build.yaml
 		ChangeLog.txt = ChangeLog.txt
 		License.txt = License.txt
-		Local.testsettings = Local.testsettings
 		ReadMe.md = ReadMe.md
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 		Build\vds-common.build = Build\vds-common.build

--- a/src/Collections/AbstractListBackedBoundedList.cs
+++ b/src/Collections/AbstractListBackedBoundedList.cs
@@ -43,8 +43,7 @@ namespace VDS.Common.Collections
         /// <param name="list">List</param>
         protected AbstractListBackedBoundedList(IList<T> list)
         {
-            if (list == null) throw new ArgumentNullException("list");
-            this._list = list;
+            this._list = list ?? throw new ArgumentNullException(nameof(list));
         }
 
         /// <summary>
@@ -60,18 +59,12 @@ namespace VDS.Common.Collections
         /// <summary>
         /// Gets the size of the list
         /// </summary>
-        public virtual int Count
-        {
-            get { return this._list.Count; }
-        }
+        public virtual int Count => this._list.Count;
 
         /// <summary>
         /// Gets whether the list is ready only
         /// </summary>
-        public virtual bool IsReadOnly
-        {
-            get { return this._list.IsReadOnly; }
-        }
+        public virtual bool IsReadOnly => this._list.IsReadOnly;
 
         /// <summary>
         /// Gets the index of the given item
@@ -97,8 +90,8 @@ namespace VDS.Common.Collections
         /// <returns>Value</returns>
         public virtual T this[int index]
         {
-            get { return this._list[index]; }
-            set { this._list[index] = value; }
+            get => this._list[index];
+            set => this._list[index] = value;
         }
 
         /// <summary>

--- a/src/Collections/BinarySparseArray.cs
+++ b/src/Collections/BinarySparseArray.cs
@@ -45,8 +45,8 @@ namespace VDS.Common.Collections
         /// <param name="length">Length</param>
         public BinarySparseArray(int length)
         {
-            if (length < 0) throw new ArgumentException("Length must be >= 0", "length");
-            this._tree = new AVLTree<int, T>(Comparer<Int32>.Default);
+            if (length < 0) throw new ArgumentException("Length must be >= 0", nameof(length));
+            this._tree = new AVLTree<int, T>(Comparer<int>.Default);
             this.Length = length;
         }
 
@@ -78,13 +78,12 @@ namespace VDS.Common.Collections
         {
             get
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in the range 0 to {0}", this.Length - 1));
-                T value;
-                return this._tree.TryGetValue(index, out value) ? value : default(T);
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in the range 0 to {this.Length - 1}");
+                return this._tree.TryGetValue(index, out T value) ? value : default;
             }
             set
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in the range 0 to {0}", this.Length - 1));
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in the range 0 to {this.Length - 1}");
                 this._tree.Add(index, value);
             }
         }
@@ -103,7 +102,7 @@ namespace VDS.Common.Collections
         }
     }
 
-    class BinarySparseArrayEnumerator<T>
+    internal class BinarySparseArrayEnumerator<T>
         : IEnumerator<T>
     {
         public BinarySparseArrayEnumerator(int length, IEnumerator<IBinaryTreeNode<int, T>> nodesEnumerator)
@@ -158,15 +157,12 @@ namespace VDS.Common.Collections
                 if (this.Index >= this.Length) throw new InvalidOperationException("Past the end of the enumerator");
 
                 // If no node either the linked list is empty or we've reached the end of it in which case simply return the default value
-                if (this.CurrentNode == null) return default(T);
+                if (this.CurrentNode == null) return default;
                 // If we reached the index of the current node then return the value otherwise we have not reached it yet and we return the default value
-                return this.CurrentNode.Key == this.Index ? this.CurrentNode.Value : default(T);
+                return this.CurrentNode.Key == this.Index ? this.CurrentNode.Value : default;
             }
         }
 
-        object IEnumerator.Current
-        {
-            get { return Current; }
-        }
+        object IEnumerator.Current => Current;
     }
 }

--- a/src/Collections/BlockSparseArray.cs
+++ b/src/Collections/BlockSparseArray.cs
@@ -49,22 +49,15 @@ namespace VDS.Common.Collections
         private readonly SparseBlock<T>[] _blocks;
 
         /// <summary>
-        /// Creates a new sparse array with the default block size
-        /// </summary>
-        /// <param name="length">Length of the array</param>
-        public BlockSparseArray(int length)
-            : this(length, DefaultBlockSize) { }
-
-        /// <summary>
         /// Creates a new sparse array
         /// </summary>
         /// <param name="length">Length</param>
         /// <param name="blockSize">Block Size</param>
-        public BlockSparseArray(int length, int blockSize)
+        public BlockSparseArray(int length, int blockSize = DefaultBlockSize)
         {
-            if (length < 0) throw new ArgumentException("Length must be >= 0", "length");
-            if (blockSize < 1) throw new ArgumentException("Block Size must be >= 1", "blockSize");
-            int numBlocks = (length/blockSize) + (length%blockSize);
+            if (length < 0) throw new ArgumentException("Length must be >= 0", nameof(length));
+            if (blockSize < 1) throw new ArgumentException("Block Size must be >= 1", nameof(blockSize));
+            int numBlocks = length/blockSize + length%blockSize;
             this._blocks = new SparseBlock<T>[numBlocks];
 
             this.BlockSize = blockSize;
@@ -98,14 +91,14 @@ namespace VDS.Common.Collections
         {
             get
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in the range 0 to {0}", this.Length - 1));
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in the range 0 to {this.Length - 1}");
                 int blockIndex = index / this.BlockSize;
                 SparseBlock<T> block = this._blocks[blockIndex];
-                return block != null ? block[index] : default(T);
+                return block != null ? block[index] : default;
             }
             set
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in the range 0 to {0}", this.Length - 1));
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in the range 0 to {this.Length - 1}");
                 int blockIndex = index / this.BlockSize;
                 SparseBlock<T> block = this._blocks[blockIndex];
                 if (block == null)
@@ -141,14 +134,14 @@ namespace VDS.Common.Collections
         }
     }
 
-    class SparseBlock<T>
+    internal class SparseBlock<T>
     {
         private readonly T[] _block;
 
         public SparseBlock(int startIndex, int length)
         {
-            if (startIndex < 0) throw new ArgumentException("Start Index must be >= 0", "startIndex");
-            if (length <= 0) throw new ArgumentException("Length must be >= 1", "length");
+            if (startIndex < 0) throw new ArgumentOutOfRangeException(nameof(startIndex),"Start Index must be >= 0");
+            if (length <= 0) throw new ArgumentOutOfRangeException(nameof(length),"Length must be >= 1");
             this.StartIndex = startIndex;
             this.Length = length;
             this._block = new T[length];
@@ -160,12 +153,12 @@ namespace VDS.Common.Collections
 
         public T this[int index]
         {
-            get { return this._block[index - this.StartIndex]; }
-            set { this._block[index - this.StartIndex] = value; }
+            get => this._block[index - this.StartIndex];
+            set => this._block[index - this.StartIndex] = value;
         }
     }
 
-    class BlockSparseArrayEnumerator<T>
+    internal class BlockSparseArrayEnumerator<T>
         : IEnumerator<T>
     {
         public BlockSparseArrayEnumerator(IEnumerator blocks, int length, int blockSize)
@@ -219,16 +212,13 @@ namespace VDS.Common.Collections
 
                 // If no current block return default value
                 SparseBlock<T> currentBlock = (SparseBlock<T>) this.Blocks.Current;
-                if (currentBlock == null) return default(T);
+                if (currentBlock == null) return default;
 
                 // Otherwise return the value within the block
                 return currentBlock[this.Index];
             }
         }
 
-        object IEnumerator.Current
-        {
-            get { return Current; }
-        }
+        object IEnumerator.Current => Current;
     }
 }

--- a/src/Collections/CappedBoundedList.cs
+++ b/src/Collections/CappedBoundedList.cs
@@ -39,7 +39,7 @@ namespace VDS.Common.Collections
         public CappedBoundedList(int capacity)
             : base(new List<T>(SelectInitialCapacity(capacity)))
         {
-            if (capacity < 0) throw new ArgumentException("MaxCapacity must be >= 0", "capacity");
+            if (capacity < 0) throw new ArgumentException("MaxCapacity must be >= 0", nameof(capacity));
             this.MaxCapacity = capacity;
         }
 
@@ -63,15 +63,12 @@ namespace VDS.Common.Collections
         /// <summary>
         /// Gets the overflow policy for this bounded list which is <see cref="BoundedListOverflowPolicy.Error"/>
         /// </summary>
-        public override BoundedListOverflowPolicy OverflowPolicy
-        {
-            get { return BoundedListOverflowPolicy.Error; }
-        }
+        public override BoundedListOverflowPolicy OverflowPolicy => BoundedListOverflowPolicy.Error;
 
         /// <summary>
         /// Gets the maximum capacity of the list
         /// </summary>
-        public override int MaxCapacity { get; protected set; }
+        public sealed override int MaxCapacity { get; protected set; }
 
         /// <summary>
         /// Inserts an item into the list at the given index
@@ -88,7 +85,7 @@ namespace VDS.Common.Collections
         /// Adds an item to the list
         /// </summary>
         /// <param name="item">Item</param>
-        public override void Add(T item)
+        public sealed override void Add(T item)
         {
             if (this._list.Count == this.MaxCapacity) throw new InvalidOperationException("Cannot add an item to this bounded list since it would cause the configured capacity of " + this.MaxCapacity + " to be exceeded");
             this._list.Add(item);

--- a/src/Collections/DiscardingBoundedList.cs
+++ b/src/Collections/DiscardingBoundedList.cs
@@ -39,7 +39,7 @@ namespace VDS.Common.Collections
         public DiscardingBoundedList(int capacity)
             : base(new List<T>(SelectInitialCapacity(capacity)))
         {
-            if (capacity < 0) throw new ArgumentException("MaxCapacity must be >= 0", "capacity");
+            if (capacity < 0) throw new ArgumentException("MaxCapacity must be >= 0", nameof(capacity));
             this.MaxCapacity = capacity;
         }
 
@@ -79,7 +79,7 @@ namespace VDS.Common.Collections
         /// Adds an item
         /// </summary>
         /// <param name="item">Item</param>
-        public override sealed void Add(T item)
+        public sealed override void Add(T item)
         {
             if (this._list.Count == this.MaxCapacity) return;
             this._list.Add(item);
@@ -88,14 +88,11 @@ namespace VDS.Common.Collections
         /// <summary>
         /// Gets the overflow policy for this bounded list which is <see cref="BoundedListOverflowPolicy.Discard"/>
         /// </summary>
-        public override BoundedListOverflowPolicy OverflowPolicy
-        {
-            get { return BoundedListOverflowPolicy.Discard; }
-        }
+        public override BoundedListOverflowPolicy OverflowPolicy => BoundedListOverflowPolicy.Discard;
 
         /// <summary>
         /// Gets the maximum capacity of the list
         /// </summary>
-        public override sealed int MaxCapacity { get; protected set; }
+        public sealed override int MaxCapacity { get; protected set; }
     }
 }

--- a/src/Collections/Enumerations/AbstractEqualityEnumerable.cs
+++ b/src/Collections/Enumerations/AbstractEqualityEnumerable.cs
@@ -22,8 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Collections.Enumerations
 {
@@ -42,8 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractEqualityEnumerable(IEnumerable<T> enumerable, IEqualityComparer<T> equalityComparer)
             : base(enumerable)
         {
-            if (equalityComparer == null) throw new ArgumentNullException("equalityComparer");
-            this.EqualityComparer = equalityComparer;
+            this.EqualityComparer = equalityComparer ?? throw new ArgumentNullException(nameof(equalityComparer));
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/AbstractEqualityEnumerator.cs
+++ b/src/Collections/Enumerations/AbstractEqualityEnumerator.cs
@@ -40,8 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractEqualityEnumerator(IEnumerator<T> enumerator, IEqualityComparer<T> equalityComparer) 
             : base(enumerator)
         {
-            if (equalityComparer == null) throw new ArgumentNullException("equalityComparer");
-            this.EqualityComparer = equalityComparer;
+            this.EqualityComparer = equalityComparer ?? throw new ArgumentNullException(nameof(equalityComparer));
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/AbstractOrderedEnumerable.cs
+++ b/src/Collections/Enumerations/AbstractOrderedEnumerable.cs
@@ -40,8 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractOrderedEnumerable(IEnumerable<T> enumerable, IComparer<T> comparer)
             : base(enumerable)
         {
-            if (comparer == null) throw new ArgumentNullException("comparer");
-            this.Comparer = comparer;
+            this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/AbstractOrderedEnumerator.cs
+++ b/src/Collections/Enumerations/AbstractOrderedEnumerator.cs
@@ -40,8 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractOrderedEnumerator(IEnumerator<T> enumerator, IComparer<T> comparer)
             : base(enumerator)
         {
-            if (comparer == null) throw new ArgumentNullException("comparer");
-            this.Comparer = comparer;
+            this.Comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/AbstractTopNEnumerable.cs
+++ b/src/Collections/Enumerations/AbstractTopNEnumerable.cs
@@ -41,7 +41,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractTopNEnumerable(IEnumerable<T> enumerable, IComparer<T> comparer, long n)
             : base(enumerable, comparer)
         {
-            if (n < 1) throw new ArgumentException("N must be >= 1", "n");
+            if (n < 1) throw new ArgumentException("N must be >= 1", nameof(n));
             this.N = n;
         }
 

--- a/src/Collections/Enumerations/AbstractTopNEnumerator.cs
+++ b/src/Collections/Enumerations/AbstractTopNEnumerator.cs
@@ -41,7 +41,7 @@ namespace VDS.Common.Collections.Enumerations
         protected AbstractTopNEnumerator(IEnumerator<T> enumerator, IComparer<T> comparer, long n)
             : base(enumerator, comparer)
         {
-            if (n < 1) throw new ArgumentException("N must be >= 1", "n");
+            if (n < 1) throw new ArgumentException("N must be >= 1", nameof(n));
             this.N = n;
         }
 
@@ -66,13 +66,10 @@ namespace VDS.Common.Collections.Enumerations
         protected override bool TryMoveNext(out T item)
         {
             // First time this is accessed need to populate the Top N items list
-            if (this.TopItemsEnumerator == null)
-            {
-                this.TopItemsEnumerator = this.BuildTopItems();
-            }
+            this.TopItemsEnumerator ??= this.BuildTopItems();
 
             // Afterwards we just pull items from that list
-            item = default(T);
+            item = default;
             if (!this.TopItemsEnumerator.MoveNext()) return false;
             item = this.TopItemsEnumerator.Current;
             return true;

--- a/src/Collections/Enumerations/AbstractWrapperEnumerable.cs
+++ b/src/Collections/Enumerations/AbstractWrapperEnumerable.cs
@@ -39,8 +39,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <param name="enumerable">Enumerable to wrap</param>
         protected AbstractWrapperEnumerable(IEnumerable<T> enumerable)
         {
-            if (enumerable == null) throw new ArgumentNullException("enumerable");
-            this.InnerEnumerable = enumerable;
+            this.InnerEnumerable = enumerable ?? throw new ArgumentNullException(nameof(enumerable));
         }
         
         /// <summary>

--- a/src/Collections/Enumerations/AbstractWrapperEnumerator.cs
+++ b/src/Collections/Enumerations/AbstractWrapperEnumerator.cs
@@ -41,8 +41,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <param name="enumerator">Enumerator to wrap</param>
         protected AbstractWrapperEnumerator(IEnumerator<T> enumerator)
         {
-            if (enumerator == null) throw new ArgumentNullException("enumerator");
-            this.InnerEnumerator = enumerator;
+            this.InnerEnumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
         }
 
         /// <summary>
@@ -79,8 +78,7 @@ namespace VDS.Common.Collections.Enumerations
         {
             this.Started = true;
             if (this.Finished) return false;
-            T item;
-            if (this.TryMoveNext(out item))
+            if (this.TryMoveNext(out T item))
             {
                 this.Current = item;
                 return true;

--- a/src/Collections/Enumerations/AddIfEmptyEnumerator.cs
+++ b/src/Collections/Enumerations/AddIfEmptyEnumerator.cs
@@ -64,7 +64,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <returns>True if an item is available, false otherwise</returns>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
             if (this.InnerEnumerator.MoveNext())
             {
                 this.AnyItemsSeen = true;

--- a/src/Collections/Enumerations/AddIfMissingEnumerator.cs
+++ b/src/Collections/Enumerations/AddIfMissingEnumerator.cs
@@ -66,7 +66,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <returns></returns>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
             if (this.InnerEnumerator.MoveNext())
             {
                 item = this.InnerEnumerator.Current;

--- a/src/Collections/Enumerations/EnumerableExtensions.cs
+++ b/src/Collections/Enumerations/EnumerableExtensions.cs
@@ -254,8 +254,8 @@ namespace VDS.Common.Collections.Enumerations
         public static IEnumerable<T> ProbabilisticDistinct<T>(this IEnumerable<T> enumerable, long expectedItems, long errorRate, Func<T, int> h1, Func<T, int> h2)
         {
             IBloomFilterParameters parameters = BloomUtils.CalculateBloomParameters(expectedItems, errorRate);
-            Func<IBloomFilter<T>> filterFactory = () => new SparseFastBloomFilter<T>(parameters, h1, h2);
-            return new ProbabilisticDistinctEnumerable<T>(enumerable, filterFactory);
+            IBloomFilter<T> FilterFactory() => new SparseFastBloomFilter<T>(parameters, h1, h2);
+            return new ProbabilisticDistinctEnumerable<T>(enumerable, FilterFactory);
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/LongSkipEnumerable.cs
+++ b/src/Collections/Enumerations/LongSkipEnumerable.cs
@@ -40,7 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         public LongSkipEnumerable(IEnumerable<T> enumerable, long toSkip)
             : base(enumerable)
         {
-            if (toSkip <= 0) throw new ArgumentException("toSkip must be > 0", "toSkip");
+            if (toSkip <= 0) throw new ArgumentException("toSkip must be > 0", nameof(toSkip));
             this.ToSkip = toSkip;
         }
 

--- a/src/Collections/Enumerations/LongSkipEnumerator.cs
+++ b/src/Collections/Enumerations/LongSkipEnumerator.cs
@@ -40,7 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         public LongSkipEnumerator(IEnumerator<T> enumerator, long toSkip)
             : base(enumerator)
         {
-            if (toSkip <= 0) throw new ArgumentException("toSkip must be > 0", "toSkip");
+            if (toSkip <= 0) throw new ArgumentException("toSkip must be > 0", nameof(toSkip));
             this.ToSkip = toSkip;
             this.Skipped = 0;
         }
@@ -79,18 +79,17 @@ namespace VDS.Common.Collections.Enumerations
         /// </remarks>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
 
             // If we've previously done the skipping so can just defer to inner enumerator
-            if (this.Skipped == this.ToSkip)
-            {
-                if (!this.InnerEnumerator.MoveNext()) return false;
-                item = this.InnerEnumerator.Current;
-                return true;
-            }
+            if (this.Skipped != this.ToSkip)
+                return this.TrySkip() && this.TryMoveNext(out item);
+            if (!this.InnerEnumerator.MoveNext())
+                return false;
+            item = this.InnerEnumerator.Current;
+            return true;
 
             // First time being accessed so attempt to skip if possible
-            return this.TrySkip() && this.TryMoveNext(out item);
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/LongTakeEnumerable.cs
+++ b/src/Collections/Enumerations/LongTakeEnumerable.cs
@@ -40,7 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         public LongTakeEnumerable(IEnumerable<T> enumerable, long toTake)
             : base(enumerable)
         {
-            if (toTake <= 0) throw new ArgumentException("toTake must be > 0", "toTake");
+            if (toTake <= 0) throw new ArgumentException("toTake must be > 0", nameof(toTake));
             this.ToTake = toTake;
         }
 

--- a/src/Collections/Enumerations/LongTakeEnumerator.cs
+++ b/src/Collections/Enumerations/LongTakeEnumerator.cs
@@ -40,7 +40,7 @@ namespace VDS.Common.Collections.Enumerations
         public LongTakeEnumerator(IEnumerator<T> enumerator, long toTake)
             : base(enumerator)
         {
-            if (toTake <= 0) throw new ArgumentException("toTake must be > 0", "toTake");
+            if (toTake <= 0) throw new ArgumentException("toTake must be > 0", nameof(toTake));
             this.ToTake = toTake;
             this.Taken = 0;
         }
@@ -65,7 +65,7 @@ namespace VDS.Common.Collections.Enumerations
         /// </remarks>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
             if (this.Taken >= this.ToTake) return false;
             if (!this.InnerEnumerator.MoveNext()) return false;
 

--- a/src/Collections/Enumerations/ProbabilisticDistinctEnumerable.cs
+++ b/src/Collections/Enumerations/ProbabilisticDistinctEnumerable.cs
@@ -44,8 +44,7 @@ namespace VDS.Common.Collections.Enumerations
         public ProbabilisticDistinctEnumerable(IEnumerable<T> enumerable, Func<IBloomFilter<T>> filterFactory)
             : base(enumerable)
         {
-            if (filterFactory == null) throw new ArgumentNullException("filterFactory");
-            this.FilterFactory = filterFactory;
+            this.FilterFactory = filterFactory ?? throw new ArgumentNullException(nameof(filterFactory));
         }
 
         /// <summary>

--- a/src/Collections/Enumerations/ProbabilisticDistinctEnumerator.cs
+++ b/src/Collections/Enumerations/ProbabilisticDistinctEnumerator.cs
@@ -44,8 +44,7 @@ namespace VDS.Common.Collections.Enumerations
         public ProbabilisticDistinctEnumerator(IEnumerator<T> enumerator, IBloomFilter<T> filter)
             : base(enumerator)
         {
-            if (filter == null) throw new ArgumentNullException("filter");
-            this.Filter = filter;
+            this.Filter = filter ?? throw new ArgumentNullException(nameof(filter));
         }
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <returns></returns>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
             while (this.InnerEnumerator.MoveNext())
             {
                 item = this.InnerEnumerator.Current;

--- a/src/Collections/Enumerations/ReducedEnumerator.cs
+++ b/src/Collections/Enumerations/ReducedEnumerator.cs
@@ -59,7 +59,7 @@ namespace VDS.Common.Collections.Enumerations
         /// <returns></returns>
         protected override bool TryMoveNext(out T item)
         {
-            item = default(T);
+            item = default;
             if (this.InnerEnumerator.MoveNext()) return false;
             item = this.InnerEnumerator.Current;
 
@@ -90,7 +90,7 @@ namespace VDS.Common.Collections.Enumerations
         protected override void ResetInternal()
         {
             this.First = true;
-            this.LastItem = default(T);
+            this.LastItem = default;
         }
     }
 }

--- a/src/Collections/Enumerations/TopNDistinctEnumerator.cs
+++ b/src/Collections/Enumerations/TopNDistinctEnumerator.cs
@@ -62,7 +62,7 @@ namespace VDS.Common.Collections.Enumerations
                 if (this.TopItems.ContainsKey(item)) continue;
 
                 this.TopItems.Add(this.InnerEnumerator.Current, true);
-                int count = this.TopItems.Root != null ? this.TopItems.Root.Size : 0;
+                int count = this.TopItems.Root?.Size ?? 0;
                 if (count > this.N) this.TopItems.RemoveAt(count - 1);
             }
             return this.TopItems.Keys.GetEnumerator();

--- a/src/Collections/ImmutableView.cs
+++ b/src/Collections/ImmutableView.cs
@@ -33,25 +33,25 @@ namespace VDS.Common.Collections
     public class ImmutableView<T>
         : ICollection<T>
     {
-        private const String DefaultErrorMessage = "This collection is immutable";
+        private const string DefaultErrorMessage = "This collection is immutable";
 
         /// <summary>
         /// The enumerable being wrapped
         /// </summary>
         protected IEnumerable<T> _items;
-        private readonly String _errMsg;
+        private readonly string _errMsg;
 
         /// <summary>
         /// Creates a new immutable view over an empty collection
         /// </summary>
         public ImmutableView()
-            : this(Enumerable.Empty<T>(), DefaultErrorMessage) { }
+            : this(Enumerable.Empty<T>()) { }
 
         /// <summary>
         /// Creates a new immutable view over an empty collection
         /// </summary>
         /// <param name="message">Error message to throw when mutation actions are attempted</param>
-        public ImmutableView(String message)
+        public ImmutableView(string message)
             : this(Enumerable.Empty<T>(), message) { }
 
         /// <summary>
@@ -59,18 +59,11 @@ namespace VDS.Common.Collections
         /// </summary>
         /// <param name="items">Enumerable to provide view over</param>
         /// <param name="message">Error message to throw when mutation actions are attempted</param>
-        public ImmutableView(IEnumerable<T> items, String message)
+        public ImmutableView(IEnumerable<T> items, string message = DefaultErrorMessage)
         {
             this._items = items;
-            this._errMsg = (!String.IsNullOrEmpty(message) ? message : DefaultErrorMessage);
+            this._errMsg = !string.IsNullOrEmpty(message) ? message : DefaultErrorMessage;
         }
-
-        /// <summary>
-        /// Creates a new immutable view
-        /// </summary>
-        /// <param name="items">Enumerable to provide view over</param>
-        public ImmutableView(IEnumerable<T> items)
-            : this(items, DefaultErrorMessage) { }
 
         /// <summary>
         /// Throws an error as this collection is immutable
@@ -108,9 +101,9 @@ namespace VDS.Common.Collections
         /// <param name="arrayIndex">Index to start the copying at</param>
         public void CopyTo(T[] array, int arrayIndex)
         {
-            if (array == null) throw new ArgumentNullException("array", "Cannot copy to a null array");
-            if (arrayIndex < 0) throw new ArgumentOutOfRangeException("arrayIndex", "Cannot start copying at index < 0");
-            if (this.Count > array.Length - arrayIndex) throw new ArgumentException("Insufficient space in array", "array");
+            if (array == null) throw new ArgumentNullException(nameof(array), "Cannot copy to a null array");
+            if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex), "Cannot start copying at index < 0");
+            if (this.Count > array.Length - arrayIndex) throw new ArgumentException("Insufficient space in array", nameof(array));
 
             int i = arrayIndex;
             foreach (T item in this._items)
@@ -188,7 +181,7 @@ namespace VDS.Common.Collections
         /// Creates a new immutable view over an empty collection
         /// </summary>
         /// <param name="message">Error message to throw when mutation actions are attempted</param>
-        public MaterializedImmutableView(String message)
+        public MaterializedImmutableView(string message)
             : base(new List<T>(), message) { }
 
         /// <summary>
@@ -196,7 +189,7 @@ namespace VDS.Common.Collections
         /// </summary>
         /// <param name="items">Enumerable to provide view over</param>
         /// <param name="message">Error message to throw when mutation actions are attempted</param>
-        public MaterializedImmutableView(IEnumerable<T> items, String message)
+        public MaterializedImmutableView(IEnumerable<T> items, string message)
             : base(items.ToList(), message) { }
 
         /// <summary>

--- a/src/Collections/LinkedSparseArray.cs
+++ b/src/Collections/LinkedSparseArray.cs
@@ -49,7 +49,7 @@ namespace VDS.Common.Collections
         /// <param name="length">Length</param>
         public LinkedSparseArray(int length)
         {
-            if (length < 0) throw new ArgumentException("Length must be >= 0", "length");
+            if (length < 0) throw new ArgumentException("Length must be >= 0", nameof(length));
             this.Length = length;
         }
 
@@ -80,13 +80,13 @@ namespace VDS.Common.Collections
         {
             get
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in range 0 to {0}", this.Length - 1));
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in range 0 to {this.Length - 1}");
                 LinkedListNode<SparseArrayEntry<T>> node = this.MoveToNode(index, false);
-                return node == null ? default(T) : node.Value.Value;
+                return node == null ? default : node.Value.Value;
             }
             set
             {
-                if (index < 0 || index >= this.Length) throw new IndexOutOfRangeException(String.Format("Index must be in range 0 to {0}", this.Length - 1));
+                if (index < 0 || index >= this.Length) throw new ArgumentOutOfRangeException(nameof(index), $"Index must be in range 0 to {this.Length - 1}");
                 LinkedListNode<SparseArrayEntry<T>> node = this.MoveToNode(index, true);
                 node.Value.Value = value;
             }
@@ -132,12 +132,9 @@ namespace VDS.Common.Collections
         }
     }
 
-    class SparseArrayEntry<T>
+    internal class SparseArrayEntry<T>
     {
-        public SparseArrayEntry(int index)
-            : this(index, default(T)) { }
-
-        public SparseArrayEntry(int index, T value)
+        public SparseArrayEntry(int index, T value = default)
         {
             this.Index = index;
             this.Value = value;
@@ -148,7 +145,7 @@ namespace VDS.Common.Collections
         public T Value { get; set; }
     }
 
-    class LinkedSparseArrayEnumerator<T>
+    internal class LinkedSparseArrayEnumerator<T>
         : IEnumerator<T>
     {
         public LinkedSparseArrayEnumerator(LinkedList<SparseArrayEntry<T>> linkedList, int length)
@@ -202,9 +199,9 @@ namespace VDS.Common.Collections
                 if (this.Index >= this.Length) throw new InvalidOperationException("Past the end of the enumerator");
 
                 // If no node either the linked list is empty or we've reached the end of it in which case simply return the default value
-                if (this.CurrentNode == null) return default(T);
+                if (this.CurrentNode == null) return default;
                 // If we reached the index of the current node then return the value otherwise we have not reached it yet and we return the default value
-                return this.CurrentNode.Value.Index == this.Index ? this.CurrentNode.Value.Value : default(T);
+                return this.CurrentNode.Value.Index == this.Index ? this.CurrentNode.Value.Value : default;
             }
         }
 

--- a/src/Collections/SortedDuplicatesList.cs
+++ b/src/Collections/SortedDuplicatesList.cs
@@ -20,14 +20,9 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace VDS.Common.Collections
 {
-    class SortedDuplicatesList
+    internal class SortedDuplicatesList
     {
     }
 }

--- a/src/Collections/TreeSortedDictionary.cs
+++ b/src/Collections/TreeSortedDictionary.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using VDS.Common.Trees;
 
 namespace VDS.Common.Collections
@@ -37,7 +36,7 @@ namespace VDS.Common.Collections
         : IDictionary<TKey, TValue>, IEnumerable<TValue>
     {
         private ITree<IBinaryTreeNode<TKey, TValue>, TKey, TValue> _tree;
-        private int _count = 0;
+        private int _count;
 
         /// <summary>
         /// Creates a new dictionary using the default comparer for the key type
@@ -51,7 +50,7 @@ namespace VDS.Common.Collections
         /// <param name="comparer">Comparer</param>
         public TreeSortedDictionary(IComparer<TKey> comparer)
         {
-            if (comparer == null) throw new ArgumentNullException("comparer", "Comparer cannot be null");
+            if (comparer == null) throw new ArgumentNullException(nameof(comparer), "Comparer cannot be null");
             this._tree = new AVLTree<TKey, TValue>(comparer);
         }
 
@@ -178,13 +177,11 @@ namespace VDS.Common.Collections
         /// <returns></returns>
         public bool Contains(KeyValuePair<TKey, TValue> item)
         {
-            TValue value;
-
-            if (this.TryGetValue(item.Key, out value))
+            if (this.TryGetValue(item.Key, out TValue value))
             {
                 if (value != null) return value.Equals(item.Value);
-                if (item.Value == null) return true; //Both null so equal
-                return false; //One is null so not equal
+                return item.Value == null; //Both null so equal
+                //One is null so not equal
             }
             else
             {
@@ -199,8 +196,8 @@ namespace VDS.Common.Collections
         /// <param name="arrayIndex">Index to start copying elements at</param>
         public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            if (array == null) throw new ArgumentNullException("array", "Cannot copy to a null array");
-            if (arrayIndex < 0) throw new ArgumentOutOfRangeException("arrayIndex", "Cannot start copying at index < 0");
+            if (array == null) throw new ArgumentNullException(nameof(array), "Cannot copy to a null array");
+            if (arrayIndex < 0) throw new ArgumentOutOfRangeException(nameof(arrayIndex), "Cannot start copying at index < 0");
             if (this.Count > array.Length - arrayIndex) throw new ArgumentException("Insufficient space in array");
 
             int i = arrayIndex;

--- a/src/Comparers/ReversedComparer.cs
+++ b/src/Comparers/ReversedComparer.cs
@@ -44,8 +44,7 @@ namespace VDS.Common.Comparers
         /// <param name="comparer">Comparer</param>
         public ReversedComparer(IComparer<T> comparer)
         {
-            if (comparer == null) throw new ArgumentNullException("comparer");
-            this.InnerComparer = comparer;
+            this.InnerComparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
         }
 
         /// <summary>

--- a/src/Compatibility/IsExternalInit.cs
+++ b/src/Compatibility/IsExternalInit.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48 || NET480 || NET481
+
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -20,10 +20,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace VDS.Common
 {
@@ -48,9 +45,9 @@ namespace VDS.Common
         /// </summary>
         /// <param name="obj">Object</param>
         /// <returns></returns>
-        internal static String ToSafeString(this Object obj)
+        internal static string ToSafeString(this object obj)
         {
-            return (obj != null ? obj.ToString() : String.Empty);
+            return obj != null ? obj.ToString() : string.Empty;
         }
     }
 }

--- a/src/Filters/BaseBloomFilter.cs
+++ b/src/Filters/BaseBloomFilter.cs
@@ -39,8 +39,7 @@ namespace VDS.Common.Filters
         /// <param name="storage">Storage to use</param>
         protected BaseBloomFilter(IBloomFilterStorage storage)
         {
-            if (storage == null) throw new ArgumentNullException("storage", "Storage cannot be null");
-            this.Storage = storage;
+            this.Storage = storage ?? throw new ArgumentNullException(nameof(storage), "Storage cannot be null");
         }
 
         /// <summary>

--- a/src/Filters/BaseBloomFilterParameters.cs
+++ b/src/Filters/BaseBloomFilterParameters.cs
@@ -31,7 +31,7 @@ namespace VDS.Common.Filters
         /// <summary>
         /// Gets the number of bits
         /// </summary>
-        public int NumberOfBits { get; protected set; }
+        public int NumberOfBits { get; protected init; }
 
         /// <summary>
         /// Gets the number of hash functions

--- a/src/Filters/BaseFastBloomFilter.cs
+++ b/src/Filters/BaseFastBloomFilter.cs
@@ -48,15 +48,13 @@ namespace VDS.Common.Filters
         protected BaseFastBloomFilter(IBloomFilterStorage storage, IBloomFilterParameters parameters, Func<T, int> h1, Func<T, int> h2)
             : base(storage)
         {
-            if (parameters == null) throw new ArgumentNullException("parameters", "Paramaeters cannot be null");
-            if (h1 == null) throw new ArgumentException("Hash functions cannot be null", "h1");
-            if (h2 == null) throw new ArgumentException("Hash functions cannot be null", "h2");
-            if (parameters.NumberOfBits <= parameters.NumberOfHashFunctions) throw new ArgumentException("Number of bits must be bigger than the number of hash functions", "parameters");
+            if (parameters == null) throw new ArgumentNullException(nameof(parameters), "Paramaeters cannot be null");
+            if (parameters.NumberOfBits <= parameters.NumberOfHashFunctions) throw new ArgumentException("Number of bits must be bigger than the number of hash functions", nameof(parameters));
 
             this._parameters = parameters;
             this.NumberOfBits = parameters.NumberOfBits;
-            this._h1 = h1;
-            this._h2 = h2;
+            this._h1 = h1 ?? throw new ArgumentException("Hash functions cannot be null", nameof(h1));
+            this._h2 = h2 ?? throw new ArgumentException("Hash functions cannot be null", nameof(h2));
         }
 
         /// <summary>
@@ -77,7 +75,7 @@ namespace VDS.Common.Filters
             int[] bits = new int[this._parameters.NumberOfHashFunctions];
             for (int i = 0; i < bits.Length; i++)
             {
-                bits[i] = Math.Abs(a + (i*b)) % this.NumberOfBits;
+                bits[i] = Math.Abs(a + i*b) % this.NumberOfBits;
             }
             return bits;
         }

--- a/src/Filters/BaseHybridBloomFilter.cs
+++ b/src/Filters/BaseHybridBloomFilter.cs
@@ -47,12 +47,12 @@ namespace VDS.Common.Filters
         protected BaseHybridBloomFilter(IBloomFilterStorage storage, IBloomFilterParameters parameters, IEnumerable<Func<T, int>> hashFunctions)
             : base(storage)
         {
-            if (parameters.NumberOfBits < 1) throw new ArgumentException("Number of bits must be >= 1", "parameters");
-            if (hashFunctions == null) throw new ArgumentNullException("hashFunctions");
+            if (parameters.NumberOfBits < 1) throw new ArgumentException("Number of bits must be >= 1", nameof(parameters));
+            if (hashFunctions == null) throw new ArgumentNullException(nameof(hashFunctions));
             this._hashFunctions = new List<Func<T, int>>(hashFunctions);
             this._hashFunctions.RemoveAll(f => f == null);
-            if (this._hashFunctions.Count <= 1) throw new ArgumentException("A bloom filter requires at least 2 hash functions", "hashFunctions");
-            if (parameters.NumberOfBits <= this._hashFunctions.Count) throw new ArgumentException("Number of bits must be bigger than the number of hash functions", "parameters");
+            if (this._hashFunctions.Count <= 1) throw new ArgumentException("A bloom filter requires at least 2 hash functions", nameof(hashFunctions));
+            if (parameters.NumberOfBits <= this._hashFunctions.Count) throw new ArgumentException("Number of bits must be bigger than the number of hash functions", nameof(parameters));
 
             this.NumberOfBits = parameters.NumberOfBits;
             this._parameters = parameters;
@@ -96,7 +96,7 @@ namespace VDS.Common.Filters
                         else
                         {
                             // Use arithmetic combination of the first two hash functions
-                            indices[i] = Math.Abs(a + (i*b))%this.NumberOfBits;
+                            indices[i] = Math.Abs(a + i*b)%this.NumberOfBits;
                         }
                         break;
                 }

--- a/src/Filters/BaseNaiveBloomFilter.cs
+++ b/src/Filters/BaseNaiveBloomFilter.cs
@@ -46,12 +46,12 @@ namespace VDS.Common.Filters
         protected BaseNaiveBloomFilter(IBloomFilterStorage storage, int bits, IEnumerable<Func<T, int>> hashFunctions)
             : base(storage)
         {
-            if (bits <= 0) throw new ArgumentException("Bits must be a positive value", "bits");
-            if (hashFunctions == null) throw new ArgumentNullException("hashFunctions");
+            if (bits <= 0) throw new ArgumentException("Bits must be a positive value", nameof(bits));
+            if (hashFunctions == null) throw new ArgumentNullException(nameof(hashFunctions));
             this._hashFunctions = new List<Func<T, int>>(hashFunctions);
             this._hashFunctions.RemoveAll(f => f == null);
-            if (this._hashFunctions.Count <= 1) throw new ArgumentException("A bloom filter requires at least 2 hash functions", "hashFunctions");
-            if (bits <= this._hashFunctions.Count) throw new ArgumentException("Bits must be bigger than the number of hash functions", "bits");
+            if (this._hashFunctions.Count <= 1) throw new ArgumentException("A bloom filter requires at least 2 hash functions", nameof(hashFunctions));
+            if (bits <= this._hashFunctions.Count) throw new ArgumentException("Bits must be bigger than the number of hash functions", nameof(bits));
 
             this.NumberOfBits = bits;
         }

--- a/src/Filters/BloomFilterParameters.cs
+++ b/src/Filters/BloomFilterParameters.cs
@@ -28,8 +28,6 @@ namespace VDS.Common.Filters
     public class BloomFilterParameters
         : BaseBloomFilterParameters
     {
-        private readonly int _numHashFunctions;
-
         /// <summary>
         /// Creates new parameters
         /// </summary>
@@ -38,12 +36,12 @@ namespace VDS.Common.Filters
         public BloomFilterParameters(int numBits, int numHashFunctions)
         {
             this.NumberOfBits = numBits;
-            this._numHashFunctions = numHashFunctions;
+            this.NumberOfHashFunctions = numHashFunctions;
         }
 
         /// <summary>
         /// Gets the number of hash functions
         /// </summary>
-        public override int NumberOfHashFunctions { get { return this._numHashFunctions; } }
+        public override int NumberOfHashFunctions { get; }
     }
 }

--- a/src/Filters/BloomUtils.cs
+++ b/src/Filters/BloomUtils.cs
@@ -51,8 +51,8 @@ namespace VDS.Common.Filters
         /// <returns>Bloom Filter parameters</returns>
         public static IBloomFilterParameters CalculateBloomParameters(long expectedItems, long errorRate)
         {
-            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", "expectedItems");
-            if (errorRate < 1) throw new ArgumentException("errorRate must be >= 1", "errorRate");
+            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", nameof(expectedItems));
+            if (errorRate < 1) throw new ArgumentException("errorRate must be >= 1", nameof(errorRate));
             return CalculateBloomParameters(expectedItems, 1d/errorRate);
         }
 
@@ -64,10 +64,10 @@ namespace VDS.Common.Filters
         /// <returns>Bloom Filter parameters</returns>
         public static IBloomFilterParameters CalculateBloomParameters(long expectedItems, double errorRate)
         {
-            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", "expectedItems");
-            if (errorRate < 0d || errorRate > 1d) throw new ArgumentException("errorRate must be in the range 0-1", "errorRate");
+            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", nameof(expectedItems));
+            if (errorRate is < 0d or > 1d) throw new ArgumentException("errorRate must be in the range 0-1", nameof(errorRate));
 
-            double numBits = Math.Ceiling((expectedItems*Math.Log(errorRate))/Math.Log(1d/Math.Pow(2d, Math.Log(2))));
+            double numBits = Math.Ceiling(expectedItems*Math.Log(errorRate)/Math.Log(1d/Math.Pow(2d, Math.Log(2))));
             double numHashFunctions = Math.Round(Math.Log(2d)*(numBits/expectedItems));
 
             try
@@ -76,7 +76,7 @@ namespace VDS.Common.Filters
             }
             catch (OverflowException)
             {
-                throw new ArgumentException(String.Format("The given parameters would result in a Bloom filter that required more than {0} bits/hash functions", Int32.MaxValue));
+                throw new ArgumentException($"The given parameters would result in a Bloom filter that required more than {int.MaxValue} bits/hash functions");
             }
         }
 
@@ -92,10 +92,10 @@ namespace VDS.Common.Filters
         /// <returns>Error Rate as a value between 0 and 1.0</returns>
         public static double CalculateErrorRate(long expectedItems, IBloomFilterParameters parameters)
         {
-            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", "expectedItems");
-            if (parameters == null) throw new ArgumentNullException("parameters");
+            if (expectedItems < 1) throw new ArgumentException("expectedItems must be >= 1", nameof(expectedItems));
+            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
 
-            double lnP = (-1d*((double) parameters.NumberOfBits / expectedItems))*Math.Pow(Math.Log(2), 2d);
+            double lnP = -1d*((double) parameters.NumberOfBits / expectedItems)*Math.Pow(Math.Log(2), 2d);
             return Math.Pow(Math.E, lnP);
         }
     }

--- a/src/Filters/IBloomFilter.cs
+++ b/src/Filters/IBloomFilter.cs
@@ -29,7 +29,7 @@ namespace VDS.Common.Filters
     /// <remarks>
     /// A bloom filter is a data structure that can be used to determine whether an item may have previously been seen in a memory efficient way that does not require storing the actual items.  The trade off is that it may yield false positives however it is guaranteed to never yield false negatives.  This makes it an ideal data structure for implementings things like distinctness where it doesn't matter if a few non-distinct items are discarded.
     /// </remarks>
-    public interface IBloomFilter<T> : IBloomFilterParameters
+    public interface IBloomFilter<in T> : IBloomFilterParameters
     {
         /// <summary>
         /// Adds an item to the filter

--- a/src/Filters/Storage/ArrayStorage.cs
+++ b/src/Filters/Storage/ArrayStorage.cs
@@ -38,7 +38,7 @@ namespace VDS.Common.Filters.Storage
         /// <param name="size">Size in bits of the storage</param>
         public ArrayStorage(int size)
         {
-            if (size <= 0) throw new ArgumentException("Size must be > 0", "size");
+            if (size <= 0) throw new ArgumentException("Size must be > 0", nameof(size));
             this._bits = new bool[size];
         }
 

--- a/src/Filters/Storage/SparseArrayStorage.cs
+++ b/src/Filters/Storage/SparseArrayStorage.cs
@@ -39,8 +39,8 @@ namespace VDS.Common.Filters.Storage
         /// <param name="parameters">Parameters</param>
         public SparseArrayStorage(IBloomFilterParameters parameters)
         {
-            if (parameters == null) throw new ArgumentNullException("parameters");
-            if (parameters.NumberOfBits <= 0) throw new ArgumentException("Number of bits must be > 0", "parameters");
+            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
+            if (parameters.NumberOfBits <= 0) throw new ArgumentException("Number of bits must be > 0", nameof(parameters));
             this._bits = new BlockSparseArray<bool>(parameters.NumberOfBits);
         }
         
@@ -50,7 +50,7 @@ namespace VDS.Common.Filters.Storage
         /// <param name="bits">Sparse array to use as storage</param>
         public SparseArrayStorage(ISparseArray<bool> bits)
         {
-            if (bits.Length <= 0) throw new ArgumentException("Sparse array must have length > 0", "bits");
+            if (bits.Length <= 0) throw new ArgumentException("Sparse array must have length > 0", nameof(bits));
             this._bits = bits;
         }
 

--- a/src/References/NestedReference.cs
+++ b/src/References/NestedReference.cs
@@ -22,8 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace VDS.Common.References
 {
@@ -35,7 +33,7 @@ namespace VDS.Common.References
         where T : class
     {
         private Dictionary<int, T> _values = new Dictionary<int, T>();
-        private int _currLevel = 0;
+        private int _currLevel;
         private T _currRef;
 
         /// <summary>
@@ -68,14 +66,7 @@ namespace VDS.Common.References
             }
             set
             {
-                if (this._values.ContainsKey(this._currLevel))
-                {
-                    this._values[this._currLevel] = value;
-                }
-                else
-                {
-                    this._values.Add(this._currLevel, value);
-                }
+                this._values[this._currLevel] = value;
                 this._currRef = value;
             }
         }
@@ -96,22 +87,19 @@ namespace VDS.Common.References
             if (this._currLevel == 0) throw new InvalidOperationException("Cannot decrement nesting when current nesting level is 0");
 
             //Revert to the most recent reference
-            if (this._values.ContainsKey(this._currLevel))
+            if (this._values.Remove(this._currLevel))
             {
-                this._values.Remove(this._currLevel);
                 int i = this._currLevel;
                 while (i > 1)
                 {
                     i--;
-                    if (this._values.ContainsKey(i))
+                    if (this._values.TryGetValue(i, out T theRef))
                     {
-                        this._currRef = this._values[i];
+                        this._currRef = theRef;
                         break;
                     }
-                    else
-                    {
-                        this._currRef = null;
-                    }
+
+                    this._currRef = null;
                 }
             }
             //Finally decrement the level

--- a/src/Trees/AVLTree.cs
+++ b/src/Trees/AVLTree.cs
@@ -22,8 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Trees
 {
@@ -45,7 +43,7 @@ namespace VDS.Common.Trees
         /// Creates a new AVL Tree
         /// </summary>
         public AVLTree()
-            : base() { }
+        { }
 
         /// <summary>
         /// Creates a new AVL Tree using the given key comparer
@@ -71,7 +69,7 @@ namespace VDS.Common.Trees
         /// </summary>
         /// <param name="parent">Parent</param>
         /// <param name="node">Newly isnerted node</param>
-        protected sealed override void AfterLeftInsert(IBinaryTreeNode<TKey, TValue> parent, IBinaryTreeNode<TKey, TValue> node)
+        protected override void AfterLeftInsert(IBinaryTreeNode<TKey, TValue> parent, IBinaryTreeNode<TKey, TValue> node)
         {
             this.RebalanceAfterInsert(node);
         }
@@ -81,7 +79,7 @@ namespace VDS.Common.Trees
         /// </summary>
         /// <param name="parent">Parent</param>
         /// <param name="node">Newly isnerted node</param>
-        protected sealed override void AfterRightInsert(IBinaryTreeNode<TKey, TValue> parent, IBinaryTreeNode<TKey, TValue> node)
+        protected override void AfterRightInsert(IBinaryTreeNode<TKey, TValue> parent, IBinaryTreeNode<TKey, TValue> node)
         {
             this.RebalanceAfterInsert(node);   
         }
@@ -118,7 +116,7 @@ namespace VDS.Common.Trees
         /// Applies rebalances after deletes
         /// </summary>
         /// <param name="node">Node at which the delete occurred</param>
-        protected sealed override void AfterDelete(IBinaryTreeNode<TKey, TValue> node)
+        protected override void AfterDelete(IBinaryTreeNode<TKey, TValue> node)
         {
             IBinaryTreeNode<TKey, TValue> current = node.Parent;
             while (current != null)
@@ -183,14 +181,12 @@ namespace VDS.Common.Trees
         /// <param name="node">Node</param>
         private void RotateLeft(IBinaryTreeNode<TKey, TValue> node)
         {
-            if (node == null) return;
-
-            IBinaryTreeNode<TKey, TValue> pivot = node.RightChild;
+            IBinaryTreeNode<TKey, TValue> pivot = node?.RightChild;
             if (pivot == null) return;
 
             IBinaryTreeNode<TKey, TValue> parent = node.Parent;
-            bool left = (parent != null && ReferenceEquals(node, parent.LeftChild));
-            bool atRoot = (parent == null);
+            bool left = parent != null && ReferenceEquals(node, parent.LeftChild);
+            bool atRoot = parent == null;
 
             //Update Parents
             node.Parent = pivot;
@@ -218,14 +214,12 @@ namespace VDS.Common.Trees
         /// <param name="node">Node</param>
         private void RotateRight(IBinaryTreeNode<TKey, TValue> node)
         {
-            if (node == null) return;
-
-            IBinaryTreeNode<TKey, TValue> pivot = node.LeftChild;
+            IBinaryTreeNode<TKey, TValue> pivot = node?.LeftChild;
             if (pivot == null) return;
 
             IBinaryTreeNode<TKey, TValue> parent = node.Parent;
-            bool left = (parent != null && ReferenceEquals(node, parent.LeftChild));
-            bool atRoot = (parent == null);
+            bool left = parent != null && ReferenceEquals(node, parent.LeftChild);
+            bool atRoot = parent == null;
 
             //Update Parents
             node.Parent = pivot;

--- a/src/Trees/BinaryTreeNode.cs
+++ b/src/Trees/BinaryTreeNode.cs
@@ -35,7 +35,6 @@ namespace VDS.Common.Trees
         : IBinaryTreeNode<TKey, TValue>
     {
         private IBinaryTreeNode<TKey, TValue> _left, _right;
-        private long _height = 1;
 
         /// <summary>
         /// Creates a new Binary Tree Node
@@ -139,27 +138,17 @@ namespace VDS.Common.Trees
         /// <summary>
         /// Gets the height of the subtree
         /// </summary>
-        public long Height
-        {
-            get
-            {
-                return this._height;
-            }
-            private set
-            {
-                this._height = value;
-            }
-        }
+        public long Height { get; private set; } = 1;
 
         /// <summary>
         /// Recalculates the height of the subtree
         /// </summary>
         public void RecalculateHeight()
         {
-            long newHeight = Math.Max((this._left != null ? this._left.Height : 0), (this._right != null ? this._right.Height : 0)) + 1;
-            if (newHeight == this._height) return;
-            this._height = newHeight;
-            if (this.Parent != null) this.Parent.RecalculateHeight();
+            long newHeight = Math.Max(this._left?.Height ?? 0, this._right?.Height ?? 0) + 1;
+            if (newHeight == this.Height) return;
+            this.Height = newHeight;
+            this.Parent?.RecalculateHeight();
         }
 
         /// <summary>
@@ -172,10 +161,10 @@ namespace VDS.Common.Trees
         /// </summary>
         public void RecalculateSize()
         {
-            int leftSize = this._left != null ? this._left.Size : 0;
-            int rightSize = this._right != null ? this._right.Size : 0;
+            int leftSize = this._left?.Size ?? 0;
+            int rightSize = this._right?.Size ?? 0;
             this.Size = leftSize + rightSize + 1;
-            if (this.Parent != null) this.Parent.RecalculateSize();
+            this.Parent?.RecalculateSize();
         }
 
         /// <summary>
@@ -195,7 +184,7 @@ namespace VDS.Common.Trees
         /// <returns></returns>
         public override string ToString()
         {
-            return "Key: " + this.Key.ToString() + " Value: " + this.Value.ToSafeString();
+            return $"Key: {this.Key} Value: {this.Value.ToSafeString()}";
         }
     }
 }

--- a/src/Trees/ChildNodesEnumerable.cs
+++ b/src/Trees/ChildNodesEnumerable.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Trees
 {
@@ -45,8 +44,7 @@ namespace VDS.Common.Trees
         /// <param name="tree">Binary Tree</param>
         public NodesEnumerable(IBinaryTree<TKey, TValue> tree)
         {
-            if (tree == null) throw new ArgumentNullException("tree", "Tree cannot be null");
-            this._tree = tree;
+            this._tree = tree ?? throw new ArgumentNullException(nameof(tree), "Tree cannot be null");
         }
 
         /// <summary>
@@ -102,8 +100,7 @@ namespace VDS.Common.Trees
         /// <param name="parent">Parent node</param>
         public ChildNodesEnumerable(IBinaryTreeNode<TKey, TValue> parent)
         {
-            if (parent == null) throw new ArgumentNullException("parent", "Parent cannot be null");
-            this._parent = parent;
+            this._parent = parent ?? throw new ArgumentNullException(nameof(parent), "Parent cannot be null");
         }
 
         /// <summary>
@@ -121,8 +118,7 @@ namespace VDS.Common.Trees
         public IEnumerator<IBinaryTreeNode<TKey, TValue>> GetEnumerator()
         {
             IBinaryTreeNode<TKey, TValue> child = this.Child;
-            if (child == null) return Enumerable.Empty<IBinaryTreeNode<TKey, TValue>>().GetEnumerator();
-            return child.Nodes.GetEnumerator();
+            return child == null ? Enumerable.Empty<IBinaryTreeNode<TKey, TValue>>().GetEnumerator() : child.Nodes.GetEnumerator();
         }
 
         /// <summary>

--- a/src/Trees/TreeExtensions.cs
+++ b/src/Trees/TreeExtensions.cs
@@ -20,10 +20,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Trees
 {
@@ -59,8 +56,7 @@ namespace VDS.Common.Trees
         /// <returns></returns>
         public static long GetHeight<TKey, TValue>(this IBinaryTreeNode<TKey, TValue> node)
         {
-            if (node == null) return 0;
-            return node.Height;
+            return node?.Height ?? 0;
             //return 1 + Math.Max(node.LeftChild.GetHeight(), node.RightChild.GetHeight());
         }
 
@@ -90,7 +86,7 @@ namespace VDS.Common.Trees
         {
             if (node.Parent == null) return null;
             IBinaryTreeNode<TKey, TValue> parent = node.Parent;
-            return (ReferenceEquals(node, parent.LeftChild) ? parent.RightChild : parent.LeftChild);
+            return ReferenceEquals(node, parent.LeftChild) ? parent.RightChild : parent.LeftChild;
         }
 
         /// <summary>
@@ -102,8 +98,7 @@ namespace VDS.Common.Trees
         /// <returns></returns>
         public static long GetSize<TKey, TValue>(this IBinaryTreeNode<TKey, TValue> node)
         {
-            if (node == null) return 0;
-            return node.Nodes.LongCount();
+            return node == null ? 0 : node.Nodes.LongCount();
         }
 
         /// <summary>

--- a/src/Trees/UnbalancedBinaryTree.cs
+++ b/src/Trees/UnbalancedBinaryTree.cs
@@ -35,8 +35,7 @@ namespace VDS.Common.Trees
         /// <summary>
         /// Creates a new unbalanced tree
         /// </summary>
-        public UnbalancedBinaryTree()
-            : base() { }
+        public UnbalancedBinaryTree() { }
 
         /// <summary>
         /// Creates a new unbalanced tree
@@ -52,7 +51,7 @@ namespace VDS.Common.Trees
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        protected sealed override IBinaryTreeNode<TKey, TValue> CreateNode(IBinaryTreeNode<TKey, TValue> parent, TKey key, TValue value)
+        protected override IBinaryTreeNode<TKey, TValue> CreateNode(IBinaryTreeNode<TKey, TValue> parent, TKey key, TValue value)
         {
             return new BinaryTreeNode<TKey, TValue>(parent, key, value);
         }

--- a/src/Tries/DescendantNodesEnumerable.cs
+++ b/src/Tries/DescendantNodesEnumerable.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Tries
 {
@@ -44,8 +43,7 @@ namespace VDS.Common.Tries
         /// <param name="node">Node</param>
         public DescendantNodesEnumerable(ITrieNode<TKeyBit, TValue> node)
         {
-            if (node == null) throw new ArgumentNullException("node");
-            this._node = node;
+            this._node = node ?? throw new ArgumentNullException(nameof(node));
         }
 
         /// <summary>
@@ -54,14 +52,7 @@ namespace VDS.Common.Tries
         /// <returns></returns>
         public IEnumerator<ITrieNode<TKeyBit, TValue>> GetEnumerator()
         {
-            if (this._node.IsLeaf)
-            {
-                return Enumerable.Empty<ITrieNode<TKeyBit, TValue>>().GetEnumerator();
-            }
-            else
-            {
-                return this._node.Children.Concat(this._node.Children.SelectMany(c => c.Descendants)).GetEnumerator();
-            }
+            return this._node.IsLeaf ? Enumerable.Empty<ITrieNode<TKeyBit, TValue>>().GetEnumerator() : this._node.Children.Concat(this._node.Children.SelectMany(c => c.Descendants)).GetEnumerator();
         }
 
         /// <summary>

--- a/src/Tries/SparseTrie.cs
+++ b/src/Tries/SparseTrie.cs
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace VDS.Common.Tries
 {
@@ -38,7 +37,10 @@ namespace VDS.Common.Tries
         : AbstractTrie<TKey, TKeyBit, TValue>
         where TKeyBit : struct, IEquatable<TKeyBit>
         where TValue : class
-    {   
+    {
+        /// <inheritdoc />
+        protected override ITrieNode<TKeyBit, TValue> _root { get; init; } = new SparseValueTrieNode<TKeyBit, TValue>(null, default);
+
         /// <summary>
         /// Create an empty trie with an empty root node.
         /// </summary>
@@ -69,11 +71,15 @@ namespace VDS.Common.Tries
         where TKeyBit : class, IEquatable<TKeyBit>
         where TValue : class
     {
+        
         /// <summary>
         /// Create an empty trie with an empty root node.
         /// </summary>
         public SparseReferenceTrie(Func<TKey, IEnumerable<TKeyBit>> keyMapper)
             : base(keyMapper) { }
+
+        /// <inheritdoc />
+        protected override ITrieNode<TKeyBit, TValue> _root { get; init; } = new SparseReferenceTrieNode<TKeyBit, TValue>(null, default);
 
         /// <summary>
         /// Method which creates a new child node
@@ -101,6 +107,9 @@ namespace VDS.Common.Tries
         /// <param name="keyMapper">Key Mapper</param>
         public SparseCharacterTrie(Func<TKey, IEnumerable<char>> keyMapper)
             : base(keyMapper) { }
+
+        /// <inheritdoc />
+        protected override ITrieNode<char, TValue> _root { get; init; } = new SparseCharacterTrieNode<TValue>(null, default);
 
         /// <summary>
         /// Creates the root node of the trie

--- a/src/Tries/SparseTrieNode.cs
+++ b/src/Tries/SparseTrieNode.cs
@@ -34,7 +34,7 @@ namespace VDS.Common.Tries
         where TKeyBit : struct, IEquatable<TKeyBit>
         where TValue : class
     {
-        private Nullable<TKeyBit> _singleton;
+        private TKeyBit? _singleton;
         private ITrieNode<TKeyBit, TValue> _singletonNode;
 
         /// <summary>

--- a/src/Tries/StringTrie.cs
+++ b/src/Tries/StringTrie.cs
@@ -20,7 +20,6 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-using System;
 using System.Collections.Generic;
 
 namespace VDS.Common.Tries
@@ -30,21 +29,21 @@ namespace VDS.Common.Tries
     /// </summary>
     /// <typeparam name="T">Type of values to be stored</typeparam>
     public class StringTrie<T>
-        : Trie<String, char, T>
+        : Trie<string, char, T>
         where T : class
     {
         /// <summary>
         /// Creates a new String Trie
         /// </summary>
         public StringTrie()
-            : base(StringTrie<T>.KeyMapper) { }
+            : base(KeyMapper) { }
 
         /// <summary>
         /// Key Mapper function for String Trie
         /// </summary>
         /// <param name="key">Key</param>
         /// <returns>Array of characters</returns>
-        public static IEnumerable<char> KeyMapper(String key)
+        public static IEnumerable<char> KeyMapper(string key)
         {
             return key.ToCharArray();
         }
@@ -58,7 +57,7 @@ namespace VDS.Common.Tries
     /// This is a sparse implementation so should be more memory efficient than the <see cref="StringTrie{T}"/> for many use cases
     /// </remarks>
     public class SparseStringTrie<T>
-        : SparseCharacterTrie<String, T>
+        : SparseCharacterTrie<string, T>
         where T : class
     {
         /// <summary>

--- a/src/Tries/Trie.cs
+++ b/src/Tries/Trie.cs
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace VDS.Common.Tries
 {
@@ -43,6 +42,9 @@ namespace VDS.Common.Tries
         /// </summary>
         public Trie(Func<TKey, IEnumerable<TKeyBit>> keyMapper)
             : base(keyMapper) { }
+
+        /// <inheritdoc />
+        protected override ITrieNode<TKeyBit, TValue> _root { get; init; } = new TrieNode<TKeyBit, TValue>(null, default);
 
         /// <summary>
         /// Method which creates a new child node

--- a/src/Tries/TrieValuesEnumerable.cs
+++ b/src/Tries/TrieValuesEnumerable.cs
@@ -23,7 +23,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 namespace VDS.Common.Tries
 {
@@ -44,8 +43,7 @@ namespace VDS.Common.Tries
         /// <param name="node">Node to start enumeration from</param>
         public TrieValuesEnumerable(ITrieNode<TKeyBit, TValue> node)
         {
-            if (node == null) throw new ArgumentNullException("node");
-            this._node = node;
+            this._node = node ?? throw new ArgumentNullException(nameof(node));
         }
 
         /// <summary>
@@ -54,14 +52,11 @@ namespace VDS.Common.Tries
         /// <returns></returns>
         public IEnumerator<TValue> GetEnumerator()
         {
-            if (this._node.HasValue)
+            return this._node.HasValue switch
             {
-                return this._node.Value.AsEnumerable().Concat(this._node.Descendants.Where(n => n.HasValue).Select(n => n.Value)).GetEnumerator();
-            }
-            else
-            {
-                return this._node.Descendants.Where(n => n.HasValue).Select(n => n.Value).GetEnumerator();
-            }
+                true => this._node.Value.AsEnumerable().Concat(this._node.Descendants.Where(n => n.HasValue).Select(n => n.Value)).GetEnumerator(),
+                _ => this._node.Descendants.Where(n => n.HasValue).Select(n => n.Value).GetEnumerator()
+            };
         }
 
         /// <summary>

--- a/src/VDS.Common.csproj
+++ b/src/VDS.Common.csproj
@@ -4,11 +4,13 @@
         <AssemblyTitle>VDS.Common</AssemblyTitle>
         <RootNamespace>VDS.Common</RootNamespace>
         <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
-        <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>../VDS.Common.snk</AssemblyOriginatorKeyFile>
         <PublicSign>true</PublicSign>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Configurations>Debug;Release</Configurations>
+	    <TargetFrameworks>net6.0;net7.0;net480;net481;net472</TargetFrameworks>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -22,9 +24,14 @@
         <RepositoryUrl>https://github.com/dotnetrdf/vds-common</RepositoryUrl>
         <Authors>RobVesse;kal_ahmed</Authors>
         <PackageTags>Data Structures;Tree;Trie;Binary AVL;Scapegoat Dictionary;Collections;Sparse Arrays;Bloom Filters;Enumerations;Comparers</PackageTags>
+        <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-  </ItemGroup>
+    <PropertyGroup Condition="$(TargetFramework)=='net6.0'">
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+    <PropertyGroup Condition="$(TargetFramework)=='net7.0'">
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
 </Project>

--- a/test/Collections/AbstractBoundedListContractTests.cs
+++ b/test/Collections/AbstractBoundedListContractTests.cs
@@ -76,14 +76,9 @@ namespace VDS.Common.Collections
             Assert.Throws(typeof(InvalidOperationException), () => list.Add("b"));
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractAddError2(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractAddError2([Values(1,2,10,100)]int capacity, [Values(10,100,1000)]int iterations)
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Error) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Error");
@@ -147,14 +142,9 @@ namespace VDS.Common.Collections
             Assert.AreEqual(2, list.Count);
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractAddDiscard2(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractAddDiscard2([Values(1,2,10,100)]int capacity, [Values(10,100,1000)]int iterations)
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Discard) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Discard");
@@ -414,14 +404,9 @@ namespace VDS.Common.Collections
             Assert.Throws<InvalidOperationException>(() => list.Insert(1, "b"));
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractInsertError3(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractInsertError3([Values( 1, 2, 10, 100 )] int capacity, [Values( 10, 100, 1000 )] int iterations )
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Error) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Error");
@@ -463,14 +448,9 @@ namespace VDS.Common.Collections
             }
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractInsertError4(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractInsertError4([Values(1,2,10,100)]int capacity, [Values(10,100,1000)]int iterations)
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Error) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Error");
@@ -550,14 +530,9 @@ namespace VDS.Common.Collections
             Assert.AreEqual("a", list[0]);
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractInsertDiscard3(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractInsertDiscard3([Values(1,2,10,100)]int capacity, [Values(10,100,1000)]int iterations)
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Discard) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Discard");
@@ -591,14 +566,9 @@ namespace VDS.Common.Collections
             }
         }
 
-        [TestCase(10, 100),
-         TestCase(10, 1000),
-         TestCase(1, 100),
-         TestCase(100, 10),
-         TestCase(100, 1000),
-         TestCase(2, 100),
-         TestCase(2, 1000)]
-        public void BoundedListContractInsertDiscard4(int capacity, int iterations)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void BoundedListContractInsertDiscard4([Values(1,2,10,100)]int capacity, [Values(10,100,1000)]int iterations)
         {
             IBoundedList<string> list = this.GetInstance(capacity);
             if (list.OverflowPolicy != BoundedListOverflowPolicy.Discard) Assert.Ignore("Test is only applicable to implementations with an OverflowPolicy of Discard");

--- a/test/Collections/AbstractSparseArrayContractTests.cs
+++ b/test/Collections/AbstractSparseArrayContractTests.cs
@@ -27,6 +27,7 @@ using NUnit.Framework;
 namespace VDS.Common.Collections
 {
     [TestFixture,Category("Arrays")]
+    [Parallelizable(ParallelScope.All)]
     public abstract class AbstractSparseArrayContractTests
     {
         /// <summary>
@@ -53,7 +54,7 @@ namespace VDS.Common.Collections
         public void SparseArrayEmpty2()
         {
             ISparseArray<int> array = this.CreateInstance(0);
-            Assert.Throws<IndexOutOfRangeException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 var _ = array[0];
             });
@@ -63,21 +64,15 @@ namespace VDS.Common.Collections
         public void SparseArrayEmpty3()
         {
             ISparseArray<int> array = this.CreateInstance(0);
-            Assert.Throws<IndexOutOfRangeException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
                 var _ = array[-1];
             });
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayGetSet1(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayGetSet1([Range(0,10000,1000)]int length)
         {
             ISparseArray<int> array = this.CreateInstance(length);
             Assert.AreEqual(length, array.Length);
@@ -93,49 +88,31 @@ namespace VDS.Common.Collections
             }
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayGetSet2(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayGetSet2([Range(0,10000,1000)]int length)
         {
             ISparseArray<int> array = this.CreateInstance(length);
-            Assert.Throws<IndexOutOfRangeException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
-                var _ = array[-1];
+                int _ = array[-1];
             });
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayGetSet3(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayGetSet3([Range(0,10000,1000)]int length)
         {
             ISparseArray<int> array = this.CreateInstance(length);
-            Assert.Throws<IndexOutOfRangeException>(() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
             {
-                var _ = array[length];
+                int _ = array[length];
             });
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayEnumerator1(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayEnumerator1([Range(0,500,10000)]int length)
         {
             Assert.AreNotEqual(default(int), 1);
 
@@ -155,7 +132,7 @@ namespace VDS.Common.Collections
                 Assert.AreEqual(1, array[i]);
             }
 
-            IEnumerator<int> sparsEnumerator = array.GetEnumerator();
+            using IEnumerator<int> sparsEnumerator = array.GetEnumerator();
             IEnumerator actualEnumerator = actualArray.GetEnumerator();
 
             int index = -1;
@@ -168,48 +145,40 @@ namespace VDS.Common.Collections
             Assert.AreEqual(length - 1, index);
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayEnumerator2(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayEnumerator2([Range(0,500,10000)]int length)
         {
             Assert.AreNotEqual(default(int), 1);
 
             // Completely sparse array i.e. no actual data
             ISparseArray<int> array = this.CreateInstance(length);
-            Assert.AreEqual(length, array.Length);
-
-            for (int i = 0; i < array.Length; i++)
+            Assert.Multiple(() =>
             {
-                // Should have default value
-                Assert.AreEqual(default(int), array[i]);
-            }
+                Assert.AreEqual(length, array.Length);
 
-            IEnumerator<int> enumerator = array.GetEnumerator();
+                foreach (int item in array)
+                {
+                    // Should have default value
+                    Assert.That(item, Is.EqualTo(0));
+                }
 
-            int index = -1;
-            while (enumerator.MoveNext())
-            {
-                index++;
-                Assert.AreEqual(default(int), enumerator.Current, "Incorrect value at index " + index);
-            }
-            Assert.AreEqual(length - 1, index);
+                using IEnumerator<int> enumerator = array.GetEnumerator();
+
+                int index = -1;
+                while (enumerator.MoveNext())
+                {
+                    index++;
+                    Assert.That(enumerator.Current,Is.EqualTo(0), "Incorrect value at index {0}", index);
+                }
+
+                Assert.AreEqual(length - 1, index);
+            });
         }
 
-        [TestCase(1),
-         TestCase(10),
-         TestCase(50),
-         TestCase(100),
-         TestCase(250),
-         TestCase(500),
-         TestCase(1000),
-         TestCase(10000)]
-        public void SparseArrayEnumerator3(int length)
+        [Test]
+        [Parallelizable(ParallelScope.Children)]
+        public void SparseArrayEnumerator3([Range(0,500,10000)]int length)
         {
             Assert.AreNotEqual(default(int), 1);
 

--- a/test/VDS.Common.Test.csproj
+++ b/test/VDS.Common.Test.csproj
@@ -1,9 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyTitle>VDS.Common.Test</AssemblyTitle>
     <AssemblyName>VDS.Common.Test</AssemblyName>
     <RootNamespace>VDS.Common</RootNamespace>
-    <TargetFrameworks>net6.0;net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net480;net481;net472</TargetFrameworks>
+    <Nullable>disable</Nullable>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Configurations>Debug;Release</Configurations>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../src/VDS.Common.csproj" />


### PR DESCRIPTION
Great project.
I was about to use it in a project I'm working on, and forked it mainly just to compile against .net 7.0.

Most of the changes in this pull request are language modernization, but there are some significant performance enhancements in several core classes, as well as a couple of thread safety improvements, especially with MultiDictionary.

Behavior is the same, except for a couple of places in which I changed thrown exception types to be more in line with recommendations/best practices.

All unit tests still pass, and the only behavioral changes I had to make to them were for those exceptions.

However, I also added some test cases in a few places, mostly by use of additional NUnit attributes, to allow for more combinations of inputs with less code (using Range and Value attributes on parameters, mostly).
I also explicitly specified a bit more aggressive parallelization than default for various tests that I touched.
Between that and the performance improvements to the core library types, the unit tests now complete in a little less than half the time, on average, compared to the code where I forked it, for .net core 6 and 7, and about 2/3 the time for .Net Framework versions.

I also changed the assertions in various timing tests to not fail if the expected case wasn't reached, but instead assert a warn state, since it doesn't really seem like timing tests should be a reason to fail the whole test suite.

I collected the changes into a pull request on my fork, with additional commentary for more significant commits, and that can be viewed here: https://github.com/dodexahedron/vds-common/pull/1#issue-1718281875

I did my best to stick to the existing code style, with regard to braces, indentation, and that sort of thing.
Style changes that were made are mostly things like null coalescing, null propagation, string interpolation, and simplification of complex constructs into shorter and usually more efficient constructs, such as switches, returns, and reduction of redundancies and extraneous allocations.

There are a couple of remaining issues that I didn't want to change just yet, until someone else takes a look at them. Those are notated with #warning preprocessor directives, so they're easy to find.

Note that I did bump the language version up to 9, to take advantage of some constructs. This did require implementation of a compatibility class to enable .net Framework 4.7 to use init accessors on properties. The implementation was taken from Microsoft, and the project compiles under 4.7, 4.8, and core 6 and up. I added explicit targets for several framework versions in the project files. All tests pass under all framework versions.

I'm happy to discuss any and all comments/thoughts/critiques anyone has on this change set and am more than happy to make or undo any changes everyone sees fit to add/remove.

A note about if statements that were changed to switches:
Since many of these classes can be extended, as they aren't sealed, I used the ReSharper transform that takes that into account when changing sets of if statements to switches, which generally just means there's a default case that won't prevent derived classes from working if values fall outside the expected cases. But, for the existing classes, behavior is the same.