### PR TITLE
Fix AVLTree balance corruption.

### DIFF
--- a/src/Trees/AVLTree.cs
+++ b/src/Trees/AVLTree.cs
@@ -118,16 +118,17 @@ public sealed class AvlTree<TKey, TValue>
     /// <param name="node">Node at which the delete occurred</param>
     protected override void AfterDelete(IBinaryTreeNode<TKey, TValue> node)
     {
-        var current = node.Parent;
+        var current = node;
         while (current != null)
         {
+            var next = current.Parent;
             var balance = current.GetBalance();
             if (Math.Abs(balance) == 1) break; //Short circuit where possible
             if (Math.Abs(balance) == 2)
             {
                 Rebalance(current, balance);
             }
-            current = current.Parent;
+            current = next;
         }
     }
 

--- a/src/Trees/BinaryTree.cs
+++ b/src/Trees/BinaryTree.cs
@@ -267,7 +267,7 @@ public abstract class BinaryTree<TKey, TValue>
             current.Key = successor.Key;
             current.Value = successor.Value;
             successor.Parent.RightChild = successor.HasChildren ? successor.LeftChild : null;
-            AfterDelete(current);
+            AfterDelete(successor.Parent);
             return true;
         }
         if (current.HasChildren)

--- a/test/Trees/BinaryTreeTests.cs
+++ b/test/Trees/BinaryTreeTests.cs
@@ -887,7 +887,38 @@ public class BinaryTreeTests
             Assert.AreEqual(count, tree.Nodes.Count(), "Removal of Key " + i + " did not reduce node count as expected");
         }
     }
+    
+    [Test]
+    public void BinaryTreeAvlDelete9()
+    {
+        var tree = new AvlTree<int, int>();
+        foreach (var k in new[] { 0, 1, 2, 3, 4 })
+        {
+            tree.Add(k, k);
+        }
 
+        tree.Remove(1);
+        Assert.DoesNotThrow(() =>
+        {
+            tree.Add(1, 1);
+        });
+    }
+    
+    [Test]
+    public void BinaryTreeAvlDelete10() {
+        var tree = new AvlTree<int, int>();
+        foreach (var k in new[] { 8, 6, 4, 1, 5, 7, 0, 3 })
+        {
+            tree.Add(k, k);
+        }
+
+        tree.Remove(6);
+        Assert.DoesNotThrow(() =>
+        {
+            tree.Add(2, 2);
+        });
+    }
+        
     [Test]
     public void BinaryTreeAvlIndexAccess1()
     {


### PR DESCRIPTION
This fixes two bugs that cause an AVLTree instance to remain unbalanced after deletion of an element.
This is the fix corresponding to https://github.com/dotnetrdf/vds-common/issues/28.